### PR TITLE
Support security attributes on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ tokio-core = "0.1"
 tokio-io = "0.1"
 rand = "0.3"
 mio-named-pipes = { git = "https://github.com/alexcrichton/mio-named-pipes" }
-miow = "0.2"
+miow = "0.3.2"
 log = "*"
 bytes = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ log = "*"
 bytes = "0.4"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["winbase"] }
+winapi = { version = "0.3", features = ["winbase", "winnt", "accctrl", "aclapi", "securitybaseapi", "minwinbase", "winbase"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,15 @@ use tokio_named_pipes::NamedPipe;
 
 #[cfg(windows)]
 mod win_permissions;
+
 #[cfg(windows)]
 pub use win_permissions::SecurityAttributes;
+
+#[cfg(unix)]
+mod unix_permissions;
+#[cfg(unix)]
+pub use unix_permissions::SecurityAttributes;
+
 
 
 
@@ -75,7 +82,6 @@ pub fn dummy_endpoint() -> String {
 /// ```
 pub struct Endpoint {
     path: String,
-    #[cfg(windows)]
     security_attributes: SecurityAttributes,
 }
 
@@ -123,7 +129,6 @@ impl Endpoint {
         tokio_uds::UnixListener::bind(&self.path, handle)
     }
 
-    #[cfg(windows)]
     pub fn set_security_attributes(&mut self, security_attributes: SecurityAttributes) {
         self.security_attributes = security_attributes;
     }
@@ -138,7 +143,6 @@ impl Endpoint {
     pub fn new(path: String) -> Self {
         Endpoint {
             path: path,
-            #[cfg(windows)]
             security_attributes: SecurityAttributes::empty(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,11 +416,7 @@ mod tests {
         create_pipe_with_permissions(SecurityAttributes::empty()).expect("failed with no attributes");
         create_pipe_with_permissions(SecurityAttributes::allow_everyone_create().unwrap())
             .expect("failed with attributes for creating");
-        // create_pipe_with_permissions(SecurityAttributes::allow_everyone_create().unwrap())
-        //     .expect("failed with attributes for creating");
-        // create_pipe_with_permissions(SecurityAttributes::allow_everyone_connect().unwrap())
-        //     .expect("failed with attributes for connecting");
-        // create_pipe_with_permissions(SecurityAttributes::allow_everyone_connect().unwrap())
-        //     .expect("failed with attributes for connecting");
+        create_pipe_with_permissions(SecurityAttributes::allow_everyone_connect().unwrap())
+            .expect("failed with attributes for connecting");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,9 +41,6 @@ mod unix_permissions;
 #[cfg(unix)]
 pub use unix_permissions::SecurityAttributes;
 
-
-
-
 /// For testing/examples
 pub fn dummy_endpoint() -> String {
     extern crate rand;

--- a/src/unix_permissions.rs
+++ b/src/unix_permissions.rs
@@ -1,0 +1,9 @@
+/// A NOOP struct for bringing the API between Windows and Unix up to parity. To set permissions
+/// properly on Unix, you can just use `std::os::unix::fs::PermissionsExt`.
+pub struct SecurityAttributes {}
+
+impl SecurityAttributes {
+    pub fn empty() -> Self {Self{}}
+    pub fn allow_everyone_connect() -> Self {Self{}}
+    pub fn allow_everyone_create() -> Self {Self{}}
+}

--- a/src/unix_permissions.rs
+++ b/src/unix_permissions.rs
@@ -1,6 +1,6 @@
 /// A NOOP struct for bringing the API between Windows and Unix up to parity. To set permissions
 /// properly on Unix, you can just use `std::os::unix::fs::PermissionsExt`.
-pub struct SecurityAttributes
+pub struct SecurityAttributes;
 
 impl SecurityAttributes {
     pub fn empty() -> Self { SecurityAttributes }

--- a/src/unix_permissions.rs
+++ b/src/unix_permissions.rs
@@ -1,9 +1,9 @@
 /// A NOOP struct for bringing the API between Windows and Unix up to parity. To set permissions
 /// properly on Unix, you can just use `std::os::unix::fs::PermissionsExt`.
-pub struct SecurityAttributes {}
+pub struct SecurityAttributes
 
 impl SecurityAttributes {
-    pub fn empty() -> Self {Self{}}
-    pub fn allow_everyone_connect() -> Self {Self{}}
-    pub fn allow_everyone_create() -> Self {Self{}}
+    pub fn empty() -> Self { SecurityAttributes }
+    pub fn allow_everyone_connect() -> Self { SecurityAttributes }
+    pub fn allow_everyone_create() -> Self { SecurityAttributes }
 }

--- a/src/win_permissions.rs
+++ b/src/win_permissions.rs
@@ -237,10 +237,7 @@ impl InnerAttributes {
         let mut entries = vec![everyone_ace];
         attributes.acl = Acl::new(&mut entries)?;
         attributes.descriptor.set_dacl(&attributes.acl)?;
-        // acl.acl_ptr = ptr::null_mut();
 
-
-        println!("ayy lmao");
         Ok(attributes)
     }
 

--- a/src/win_permissions.rs
+++ b/src/win_permissions.rs
@@ -1,0 +1,268 @@
+use winapi::um::winnt::*;
+use winapi::um::accctrl::*;
+use winapi::um::aclapi::*;
+use winapi::um::securitybaseapi::*;
+use winapi::um::minwinbase::{LPTR, SECURITY_ATTRIBUTES, PSECURITY_ATTRIBUTES};
+use winapi::um::winbase::{LocalAlloc, LocalFree};
+use winapi::shared::winerror::ERROR_SUCCESS;
+
+use std::ptr;
+use std::io;
+use std::mem;
+use std::marker;
+
+pub struct SecurityAttributes {
+    attributes: Option<InnerAttributes>,
+}
+
+impl SecurityAttributes {
+    pub fn empty() -> SecurityAttributes {
+        SecurityAttributes { attributes: None }
+    }
+
+    pub fn allow_everyone_connect() -> io::Result<SecurityAttributes> {
+        let attributes = Some(InnerAttributes::allow_everyone(GENERIC_READ | FILE_WRITE_DATA)?);
+        Ok(SecurityAttributes { attributes })
+    }
+
+    pub fn allow_everyone_create() -> io::Result<SecurityAttributes> {
+        let attributes = Some(InnerAttributes::allow_everyone(GENERIC_READ | GENERIC_WRITE)?);
+        Ok(SecurityAttributes { attributes })
+    }
+
+    pub unsafe fn as_ptr(&mut self) -> PSECURITY_ATTRIBUTES {
+        match self.attributes.as_mut() {
+            Some(attributes) => attributes.as_ptr(),
+            None => ptr::null_mut(),
+        }
+    }
+}
+
+unsafe impl Send for SecurityAttributes {}
+
+
+struct Sid {
+    sid_ptr: PSID
+}
+
+impl Sid {
+    fn everyone_sid() -> io::Result<Sid> {
+        let mut sid_ptr = ptr::null_mut();
+        let result = unsafe {
+            AllocateAndInitializeSid(
+                SECURITY_WORLD_SID_AUTHORITY.as_mut_ptr() as *mut _, 1,
+                SECURITY_WORLD_RID,
+                0, 0, 0, 0, 0, 0, 0,
+                &mut sid_ptr)
+        };
+        if result == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(Sid{sid_ptr})
+        }
+    }
+
+    // Unsafe - the returned pointer is only valid for the lifetime of self.
+    unsafe fn as_ptr(&self) -> PSID {
+        self.sid_ptr
+    }
+}
+
+impl Drop for Sid {
+    fn drop(&mut self) {
+        if !self.sid_ptr.is_null() {
+            unsafe{ FreeSid(self.sid_ptr); }
+        }
+    }
+}
+
+
+struct AceWithSid<'a> {
+    explicit_access: EXPLICIT_ACCESS_W,
+    _marker: marker::PhantomData<&'a Sid>,
+}
+
+impl<'a> AceWithSid<'a> {
+    fn new(sid: &'a Sid, trustee_type: u32) -> AceWithSid<'a> {
+        let mut explicit_access = unsafe { mem::zeroed::<EXPLICIT_ACCESS_W>() };
+        explicit_access.Trustee.TrusteeForm  = TRUSTEE_IS_SID;
+        explicit_access.Trustee.TrusteeType  = trustee_type;
+        explicit_access.Trustee.ptstrName    = unsafe { sid.as_ptr() as *mut _ };
+
+        AceWithSid{
+            explicit_access,
+            _marker: marker::PhantomData,
+        }
+    }
+
+    fn set_access_mode(&mut self, access_mode: u32) -> &mut Self {
+        self.explicit_access.grfAccessMode = access_mode;
+        self
+    }
+
+    fn set_access_permissions(&mut self, access_permissions: u32) -> &mut Self {
+        self.explicit_access.grfAccessPermissions = access_permissions;
+        self
+    }
+
+    fn allow_inheritance(&mut self, inheritance_flags: u32) -> &mut Self {
+        self.explicit_access.grfInheritance = inheritance_flags;
+        self
+    }
+}
+
+struct Acl {
+    acl_ptr: PACL,
+}
+
+impl Acl {
+    fn empty() -> io::Result<Acl> {
+        Self::new(&mut [])
+    }
+
+    fn new(entries: &mut [AceWithSid]) -> io::Result<Acl> {
+        let mut acl_ptr = ptr::null_mut();
+        let result = unsafe {
+            SetEntriesInAclW(entries.len() as u32,
+                entries.as_mut_ptr() as *mut _,
+                ptr::null_mut(), &mut acl_ptr)
+        };
+
+        if result != ERROR_SUCCESS {
+            return Err(io::Error::from_raw_os_error(result as i32));
+        }
+
+        Ok(Acl{acl_ptr})
+    }
+
+    unsafe fn as_ptr(&self) -> PACL {
+        self.acl_ptr
+    }
+}
+
+impl Drop for Acl {
+    fn drop(&mut self) {
+        if !self.acl_ptr.is_null() {
+            unsafe { LocalFree(self.acl_ptr as *mut _) };
+        }
+    }
+}
+
+struct SecurityDescriptor {
+    descriptor_ptr: PSECURITY_DESCRIPTOR,
+}
+
+impl SecurityDescriptor{
+    fn new() -> io::Result<Self> {
+        let descriptor_ptr = unsafe {
+            LocalAlloc(LPTR, SECURITY_DESCRIPTOR_MIN_LENGTH)
+        };
+        if descriptor_ptr.is_null() {
+            return Err(io::Error::new(io::ErrorKind::Other,
+                                      "Failed to allocate security descriptor"));
+        }
+
+        if unsafe { InitializeSecurityDescriptor(
+                descriptor_ptr,
+                SECURITY_DESCRIPTOR_REVISION) == 0 }
+        {
+            return Err(io::Error::last_os_error());
+        };
+
+        Ok(SecurityDescriptor{descriptor_ptr})
+    }
+
+    fn set_dacl(&mut self, acl: &Acl) -> io::Result<()> {
+        if unsafe {
+            SetSecurityDescriptorDacl(
+                self.descriptor_ptr,
+                true as i32, acl.as_ptr(),
+                false as i32) == 0
+        }{
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    unsafe fn as_ptr(&self) -> PSECURITY_DESCRIPTOR {
+        self.descriptor_ptr
+    }
+}
+
+impl Drop for SecurityDescriptor {
+    fn drop(&mut self) {
+        if !self.descriptor_ptr.is_null() {
+            unsafe { LocalFree(self.descriptor_ptr) };
+            self.descriptor_ptr = ptr::null_mut();
+        }
+    }
+}
+
+struct InnerAttributes {
+    descriptor: SecurityDescriptor,
+    acl: Acl,
+    attrs: SECURITY_ATTRIBUTES,
+}
+
+
+impl InnerAttributes {
+
+    fn empty() -> io::Result<InnerAttributes> {
+        let descriptor = SecurityDescriptor::new()?;
+        let mut attrs = unsafe { mem::zeroed::<SECURITY_ATTRIBUTES>() };
+        attrs.nLength = mem::size_of::<SECURITY_ATTRIBUTES>() as u32;
+        attrs.lpSecurityDescriptor = unsafe {descriptor.as_ptr()};
+        attrs.bInheritHandle = false as i32;
+
+        let acl = Acl::empty().expect("this should never fail");
+
+        Ok(InnerAttributes{
+            acl,
+            descriptor,
+            attrs,
+        })
+    }
+
+    fn allow_everyone(permissions: u32) -> io::Result<InnerAttributes> {
+        let mut attributes = Self::empty()?;
+        let sid = Sid::everyone_sid()?;
+        println!("pisec");
+
+        let mut everyone_ace = AceWithSid::new(&sid, TRUSTEE_IS_WELL_KNOWN_GROUP);
+        everyone_ace.set_access_mode(SET_ACCESS)
+                    .set_access_permissions(permissions)
+                    .allow_inheritance(false as u32);
+
+
+        let mut entries = vec![everyone_ace];
+        attributes.acl = Acl::new(&mut entries)?;
+        attributes.descriptor.set_dacl(&attributes.acl)?;
+        // acl.acl_ptr = ptr::null_mut();
+
+
+        println!("ayy lmao");
+        Ok(attributes)
+    }
+
+    unsafe fn as_ptr(&mut self) -> PSECURITY_ATTRIBUTES {
+        &mut self.attrs as *mut _
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::SecurityAttributes;
+
+    #[test]
+    fn test_allow_everyone_everything() {
+        SecurityAttributes::allow_everyone_create()
+            .expect("failed to create security attributes that allow everyone to create a pipe");
+    }
+
+    #[test]
+    fn test_allow_eveyone_read_write() {
+        SecurityAttributes::allow_everyone_connect()
+            .expect("failed to create security attributes that allow everyone to read and write to/from a pipe");
+    }
+
+}


### PR DESCRIPTION
These changes allow for setting security attributes of named pipes on Windows. The changes are quite significant, but they allow the `Endpoint` struct to be movable now but they also require changes in `jsonrpc_ipc_server` crate. A PR for those changes are up as well.

A bit of background why this is required - our use case of using this crate is to have two different processes which are ran at different privilege levels communicate with each other, the server end has to set the appropriate security attributes of the pipe, otherwise the client has to be ran with elevated privileges.