### PR TITLE
Match signatures of SecurityAttributes funcs on unix

### DIFF
--- a/src/unix_permissions.rs
+++ b/src/unix_permissions.rs
@@ -1,9 +1,16 @@
+use std::io;
+
 /// A NOOP struct for bringing the API between Windows and Unix up to parity. To set permissions
 /// properly on Unix, you can just use `std::os::unix::fs::PermissionsExt`.
 pub struct SecurityAttributes;
 
 impl SecurityAttributes {
+    /// New default security attributes.
     pub fn empty() -> Self { SecurityAttributes }
-    pub fn allow_everyone_connect() -> Self { SecurityAttributes }
-    pub fn allow_everyone_create() -> Self { SecurityAttributes }
+
+    /// New security attributes that allow everyone to connect.
+    pub fn allow_everyone_connect() -> io::Result<Self> { Ok(SecurityAttributes) }
+
+    /// New security attributes that allow everyone to create.
+    pub fn allow_everyone_create() -> io::Result<Self> { Ok(SecurityAttributes) }
 }

--- a/src/win_permissions.rs
+++ b/src/win_permissions.rs
@@ -35,7 +35,7 @@ impl SecurityAttributes {
     }
 
     /// Return raw handle of security attributes.
-    pub unsafe fn as_ptr(&mut self) -> PSECURITY_ATTRIBUTES {
+    pub(crate) unsafe fn as_ptr(&mut self) -> PSECURITY_ATTRIBUTES {
         match self.attributes.as_mut() {
             Some(attributes) => attributes.as_ptr(),
             None => ptr::null_mut(),

--- a/src/win_permissions.rs
+++ b/src/win_permissions.rs
@@ -11,25 +11,30 @@ use std::io;
 use std::mem;
 use std::marker;
 
+/// Security attributes.
 pub struct SecurityAttributes {
     attributes: Option<InnerAttributes>,
 }
 
 impl SecurityAttributes {
+    /// New default security attributes.
     pub fn empty() -> SecurityAttributes {
         SecurityAttributes { attributes: None }
     }
 
+    /// New default security attributes that allow everyone to connect.
     pub fn allow_everyone_connect() -> io::Result<SecurityAttributes> {
         let attributes = Some(InnerAttributes::allow_everyone(GENERIC_READ | FILE_WRITE_DATA)?);
         Ok(SecurityAttributes { attributes })
     }
 
+    /// New default security attributes that allow everyone to create.
     pub fn allow_everyone_create() -> io::Result<SecurityAttributes> {
         let attributes = Some(InnerAttributes::allow_everyone(GENERIC_READ | GENERIC_WRITE)?);
         Ok(SecurityAttributes { attributes })
     }
 
+    /// Return raw handle of security attributes.
     pub unsafe fn as_ptr(&mut self) -> PSECURITY_ATTRIBUTES {
         match self.attributes.as_mut() {
             Some(attributes) => attributes.as_ptr(),


### PR DESCRIPTION
Fixes #7

also `SecurityAttributes::as_ptr` is visible on crate level only 