### PR TITLE
windows: Don't panic if pipe doesn't exist

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ impl IpcConnection {
         use winapi::um::winbase::FILE_FLAG_OVERLAPPED;
 
         // Wait for the pipe to become available or fail after 5 seconds.
-        miow::pipe::NamedPipe::wait(path, Some(std::time::Duration::from_millis(PIPE_AVAILABILITY_TIMEOUT))).unwrap();
+        miow::pipe::NamedPipe::wait(path, Some(std::time::Duration::from_millis(PIPE_AVAILABILITY_TIMEOUT)))?;
         let mut options = OpenOptions::new();
         options.read(true)
             .write(true)


### PR DESCRIPTION
It looks like an oversight, since every other error is propagated to the top.

Can confirm that this allows us to fix the test in PR for the IPC JSON-RPC server at https://github.com/paritytech/jsonrpc/pull/460/files#diff-df9803a4ba4c479ee9313609c56c6f86R81

cc https://github.com/paritytech/jsonrpc/pull/460