### PR TITLE
Bring back the connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-tokio-ipc"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2018"
 authors = ["NikVolf <nikvolf@gmail.com>"]
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,16 +9,6 @@ mod win;
 #[cfg(not(windows))]
 mod unix;
 
-/// For testing/examples
-pub fn dummy_endpoint() -> String {
-	let num: u64 = rand::Rng::gen(&mut rand::thread_rng());
-	if cfg!(windows) {
-		format!(r"\\.\pipe\my-pipe-{}", num)
-	} else {
-		format!(r"/tmp/my-uds-{}", num)
-	}
-}
-
 /// Endpoint for IPC transport
 ///
 /// # Examples
@@ -44,6 +34,16 @@ pub fn dummy_endpoint() -> String {
 pub use win::{SecurityAttributes, Endpoint};
 #[cfg(unix)]
 pub use unix::{SecurityAttributes, Endpoint};
+
+/// For testing/examples
+pub fn dummy_endpoint() -> String {
+	let num: u64 = rand::Rng::gen(&mut rand::thread_rng());
+	if cfg!(windows) {
+		format!(r"\\.\pipe\my-pipe-{}", num)
+	} else {
+		format!(r"/tmp/my-uds-{}", num)
+	}
+}
 
 #[cfg(test)]
 mod tests {
@@ -83,7 +83,6 @@ mod tests {
 		};
 	}
 
-	// NOTE: Intermittently fails or stalls on windows.
 	#[tokio::test]
 	async fn smoke_test() {
 		let path = dummy_endpoint();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,9 @@ mod unix;
 /// }
 ///```
 #[cfg(windows)]
-pub use win::{SecurityAttributes, Endpoint};
+pub use win::{SecurityAttributes, Endpoint, Connection};
 #[cfg(unix)]
-pub use unix::{SecurityAttributes, Endpoint};
+pub use unix::{SecurityAttributes, Endpoint, Connection};
 
 /// For testing/examples
 pub fn dummy_endpoint() -> String {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -116,6 +116,7 @@ impl Drop for Endpoint {
     }
 }
 
+/// IPC connection.
 pub struct Connection {
     inner: UnixStream,
 }

--- a/src/win.rs
+++ b/src/win.rs
@@ -166,7 +166,7 @@ impl Stream for Incoming {
     }
 }
 
-/// IPC Connection
+/// IPC connection.
 pub struct Connection {
     inner: NamedPipe,
 }


### PR DESCRIPTION
it is impossible to store active connection anywhere when using opaque return types (`impl<AsyncRead+AsyncWrite>`) 