### PR TITLE
Make Endpoint::incoming consistently consume self on Unix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,16 @@ mod tests {
 			// assert that it has
 			assert!(!path.exists());
 		}
-	}
+    }
+
+    #[tokio::test]
+    async fn incoming_stream_is_static() {
+        fn is_static<T: 'static>(_: T) {}
+
+        let path = dummy_endpoint();
+        let endpoint = Endpoint::new(path);
+        is_static(endpoint.incoming());
+    }
 
 	#[cfg(windows)]
 	fn create_pipe_with_permissions(attr: SecurityAttributes) -> ::std::io::Result<()> {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -51,7 +51,7 @@ impl SecurityAttributes {
     fn apply_permissions(&self, path: &str) -> io::Result<()> {
         if let Some(mode) = self.mode {
             let path = CString::new(path)?;
-            if unsafe { chmod(path.as_ptr(), u32::from(mode)) } == -1 {
+            if unsafe { chmod(path.as_ptr(), mode.into()) } == -1 {
                 return Err(Error::last_os_error());
             }
         }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -64,21 +64,21 @@ impl SecurityAttributes {
 pub struct Endpoint {
     path: String,
     security_attributes: SecurityAttributes,
-    unix_listener: Option<UnixListener>,
 }
 
 impl Endpoint {
     /// Stream of incoming connections
-    pub fn incoming(&mut self) -> io::Result<impl Stream<Item = tokio::io::Result<impl AsyncRead + AsyncWrite>> + '_> {
-        self.unix_listener = Some(self.inner()?);
+    pub fn incoming(self) -> io::Result<impl Stream<Item = tokio::io::Result<impl AsyncRead + AsyncWrite>> + 'static> {
+        let listener = self.inner()?;
         unsafe {
             // the call to bind in `inner()` creates the file
             // `apply_permission()` will set the file permissions.
             self.security_attributes.apply_permissions(&self.path)?;
         };
-        // for some unknown reason, the Incoming struct borrows the listener
-        // so we have to hold on to the listener in order to return the Incoming struct.
-        Ok(self.unix_listener.as_mut().unwrap().incoming())
+        Ok(Incoming {
+            path: self.path,
+            listener,
+        })
     }
 
     /// Inner platform-dependant state of the endpoint
@@ -106,15 +106,34 @@ impl Endpoint {
         Endpoint {
             path,
             security_attributes: SecurityAttributes::empty(),
-            unix_listener: None,
         }
     }
 }
 
-impl Drop for Endpoint {
+/// Stream of incoming connections.
+///
+/// Removes the bound socket file when dropped.
+struct Incoming {
+    path: String,
+    listener: UnixListener,
+}
+
+impl Stream for Incoming {
+    type Item = io::Result<UnixStream>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let this = Pin::into_inner(self);
+        Pin::new(&mut this.listener).poll_next(cx)
+    }
+}
+
+impl Drop for Incoming {
     fn drop(&mut self) {
         use std::fs;
-        if let Ok(()) = fs::remove_file(Path::new(&self.path)) {
+        if let Ok(()) = fs::remove_file(&self.path) {
             log::trace!("Removed socket file at: {}", self.path)
         }
     }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -48,11 +48,11 @@ impl SecurityAttributes {
 
     /// called in unix, after server socket has been created
     /// will apply security attributes to the socket.
-    pub(crate) unsafe fn apply_permissions(&self, path: &str) -> io::Result<()> {
-        let path = CString::new(path.to_owned())?;
+    fn apply_permissions(&self, path: &str) -> io::Result<()> {
         if let Some(mode) = self.mode {
-            if chmod(path.as_ptr(), mode as _) == -1 {
-                return Err(Error::last_os_error())
+            let path = CString::new(path)?;
+            if unsafe { chmod(path.as_ptr(), u32::from(mode)) } == -1 {
+                return Err(Error::last_os_error());
             }
         }
 
@@ -70,11 +70,9 @@ impl Endpoint {
     /// Stream of incoming connections
     pub fn incoming(self) -> io::Result<impl Stream<Item = tokio::io::Result<impl AsyncRead + AsyncWrite>> + 'static> {
         let listener = self.inner()?;
-        unsafe {
-            // the call to bind in `inner()` creates the file
-            // `apply_permission()` will set the file permissions.
-            self.security_attributes.apply_permissions(&self.path)?;
-        };
+        // the call to bind in `inner()` creates the file
+        // `apply_permission()` will set the file permissions.
+        self.security_attributes.apply_permissions(&self.path)?;
         Ok(Incoming {
             path: self.path,
             listener,


### PR DESCRIPTION
Spotted when trying to migrate jsonrpc to futures 0.3 (WIP @ https://github.com/paritytech/jsonrpc/commit/51c2feeaebcf26ca421f59658dd79cc23a2a14ae). Ideally, we should consume `self` in both Windows and Unix cases - having one method borrow `&self` leads to lifetime issues and a grumpy compiler. Instead, I opted to consume `self` similarly to what previous implementation (futures 0.1) did and what is currently implemented for Windows.

cc @seunlanlege for the current impl