### PR TITLE
Use `const fn`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/paritytech/parity-tokio-ipc"
 description = """
 Interprocess communication library for tokio.
 """
+include = ["src/**/*", "LICENSE-*", "README.md"]
 
 [dependencies]
 futures = "0.3"

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,24 +1,33 @@
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use parity_tokio_ipc::Endpoint;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-	let path = std::env::args().nth(1).expect("Run it with server path to connect as argument");
+    let path = std::env::args()
+        .nth(1)
+        .expect("Run it with server path to connect as argument");
 
-	let mut client = Endpoint::connect(&path).await
-		.expect("Failed to connect client.");
+    let mut client = Endpoint::connect(&path)
+        .await
+        .expect("Failed to connect client.");
 
-	loop {
-		let mut buf = [0u8; 4];
-		println!("SEND: PING");
-		client.write_all(b"ping").await.expect("Unable to write message to client");
-		client.read_exact(&mut buf[..]).await.expect("Unable to read buffer");
-		if let Ok("pong") = std::str::from_utf8(&buf[..]) {
-			println!("RECEIVED: PONG");
-		} else {
-			break;
-		}
+    loop {
+        let mut buf = [0u8; 4];
+        println!("SEND: PING");
+        client
+            .write_all(b"ping")
+            .await
+            .expect("Unable to write message to client");
+        client
+            .read_exact(&mut buf[..])
+            .await
+            .expect("Unable to read buffer");
+        if let Ok("pong") = std::str::from_utf8(&buf[..]) {
+            println!("RECEIVED: PONG");
+        } else {
+            break;
+        }
 
-		tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-	}
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -20,12 +20,12 @@ async fn run_server(path: String) {
 					loop {
 						let mut buf = [0u8; 4];
 						let pong_buf = b"pong";
-						if let Err(_) = reader.read_exact(&mut buf).await {
-							println!("Closing socket");
-							break;
-						}
-						if let Ok("ping") = std::str::from_utf8(&buf[..]) {
-							println!("RECIEVED: PING");
+                        if reader.read_exact(&mut buf).await.is_err() {
+                            println!("Closing socket");
+                            break;
+                        }
+                        if let Ok("ping") = std::str::from_utf8(&buf[..]) {
+                            println!("RECIEVED: PING");
 							writer.write_all(pong_buf).await.expect("unable to write to socket");
 							println!("SEND: PONG");
 						}

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -4,41 +4,45 @@ use tokio::io::{split, AsyncReadExt, AsyncWriteExt};
 use parity_tokio_ipc::{Endpoint, SecurityAttributes};
 
 async fn run_server(path: String) {
-	let mut endpoint = Endpoint::new(path);
-	endpoint.set_security_attributes(SecurityAttributes::allow_everyone_create().unwrap());
+    let mut endpoint = Endpoint::new(path);
+    endpoint.set_security_attributes(SecurityAttributes::allow_everyone_create().unwrap());
 
-	let incoming = endpoint.incoming().expect("failed to open new socket");
-	futures::pin_mut!(incoming);
+    let incoming = endpoint.incoming().expect("failed to open new socket");
+    futures::pin_mut!(incoming);
 
-	while let Some(result) = incoming.next().await
-	{
-		match result {
-			Ok(stream) => {
-				let (mut reader, mut writer) = split(stream);
+    while let Some(result) = incoming.next().await {
+        match result {
+            Ok(stream) => {
+                let (mut reader, mut writer) = split(stream);
 
-				tokio::spawn(async move {
-					loop {
-						let mut buf = [0u8; 4];
-						let pong_buf = b"pong";
+                tokio::spawn(async move {
+                    loop {
+                        let mut buf = [0u8; 4];
+                        let pong_buf = b"pong";
                         if reader.read_exact(&mut buf).await.is_err() {
                             println!("Closing socket");
                             break;
                         }
                         if let Ok("ping") = std::str::from_utf8(&buf[..]) {
                             println!("RECIEVED: PING");
-							writer.write_all(pong_buf).await.expect("unable to write to socket");
-							println!("SEND: PONG");
-						}
-					}
-				});
-			}
-			_ => unreachable!("ideally")
-		}
-	};
+                            writer
+                                .write_all(pong_buf)
+                                .await
+                                .expect("unable to write to socket");
+                            println!("SEND: PONG");
+                        }
+                    }
+                });
+            }
+            _ => unreachable!("ideally"),
+        }
+    }
 }
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-	let path = std::env::args().nth(1).expect("Run it with server path as argument");
-	run_server(path).await
+    let path = std::env::args()
+        .nth(1)
+        .expect("Run it with server path as argument");
+    run_server(path).await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,11 +182,7 @@ mod tests {
             .expect("failed with no attributes");
         create_pipe_with_permissions(SecurityAttributes::allow_everyone_create().unwrap())
             .expect("failed with attributes for creating");
-        create_pipe_with_permissions(
-            SecurityAttributes::empty()
-                .allow_everyone_connect()
-                .unwrap(),
-        )
-        .expect("failed with attributes for connecting");
+        create_pipe_with_permissions(SecurityAttributes::allow_everyone_connect().unwrap())
+            .expect("failed with attributes for connecting");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,17 +10,19 @@
 macro_rules! doc_comment {
     ($x:expr) => {
         #[doc = $x]
-        extern {}
+        extern "C" {}
     };
 }
 
 doc_comment!(include_str!("../README.md"));
 
-#[cfg(windows)]
-mod win;
 #[cfg(not(windows))]
 mod unix;
+#[cfg(windows)]
+mod win;
 
+#[cfg(unix)]
+pub use unix::{Connection, Endpoint, SecurityAttributes};
 /// Endpoint for IPC transport
 ///
 /// # Examples
@@ -43,102 +45,116 @@ mod unix;
 /// }
 ///```
 #[cfg(windows)]
-pub use win::{SecurityAttributes, Endpoint, Connection};
-#[cfg(unix)]
-pub use unix::{SecurityAttributes, Endpoint, Connection};
+pub use win::{Connection, Endpoint, SecurityAttributes};
 
 /// For testing/examples
+#[must_use]
 pub fn dummy_endpoint() -> String {
-	let num: u64 = rand::Rng::gen(&mut rand::thread_rng());
-	if cfg!(windows) {
-		format!(r"\\.\pipe\my-pipe-{}", num)
-	} else {
-		format!(r"/tmp/my-uds-{}", num)
-	}
+    let num: u64 = rand::Rng::gen(&mut rand::thread_rng());
+    if cfg!(windows) {
+        format!(r"\\.\pipe\my-pipe-{}", num)
+    } else {
+        format!(r"/tmp/my-uds-{}", num)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use futures::{channel::oneshot, StreamExt as _, FutureExt as _};
-	use std::time::Duration;
-	use tokio::io::{split, AsyncReadExt, AsyncWriteExt};
+    use futures::{channel::oneshot, FutureExt as _, StreamExt as _};
+    use std::time::Duration;
+    use tokio::io::{split, AsyncReadExt, AsyncWriteExt};
 
-	use super::{dummy_endpoint, Endpoint, SecurityAttributes};
-	use std::path::Path;
-	use futures::future::{Either, select, ready};
+    use super::{dummy_endpoint, Endpoint, SecurityAttributes};
+    use futures::future::{ready, select, Either};
+    use std::path::Path;
 
-	async fn run_server(path: String) {
-		let path = path.to_owned();
-		let mut endpoint = Endpoint::new(path);
+    async fn run_server(path: String) {
+        let path = path.clone();
+        let mut endpoint = Endpoint::new(path);
 
-		endpoint.set_security_attributes(
-			SecurityAttributes::empty()
-				.set_mode(0o777)
-				.unwrap()
-		);
-		let incoming = endpoint.incoming().expect("failed to open up a new socket");
-		futures::pin_mut!(incoming);
+        endpoint.set_security_attributes(SecurityAttributes::empty().set_mode(0o777).unwrap());
+        let incoming = endpoint.incoming().expect("failed to open up a new socket");
+        futures::pin_mut!(incoming);
 
-		while let Some(result) = incoming.next().await {
-			match result {
-				Ok(stream) => {
-					let (mut reader, mut writer) = split(stream);
-					let mut buf = [0u8; 5];
-					reader.read_exact(&mut buf).await.expect("unable to read from socket");
-					writer.write_all(&buf[..]).await.expect("unable to write to socket");
-				}
-				_ => unreachable!("ideally")
-			}
-		};
-	}
+        while let Some(result) = incoming.next().await {
+            match result {
+                Ok(stream) => {
+                    let (mut reader, mut writer) = split(stream);
+                    let mut buf = [0_u8; 5];
+                    reader
+                        .read_exact(&mut buf)
+                        .await
+                        .expect("unable to read from socket");
+                    writer
+                        .write_all(&buf[..])
+                        .await
+                        .expect("unable to write to socket");
+                }
+                _ => unreachable!("ideally"),
+            }
+        }
+    }
 
-	#[tokio::test]
-	async fn smoke_test() {
-		let path = dummy_endpoint();
-		let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    #[tokio::test]
+    async fn smoke_test() {
+        let path = dummy_endpoint();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
-		let server = select(Box::pin(run_server(path.clone())), shutdown_rx)
-			.then(|either| {
-				match either {
-					Either::Right((_, server)) => {
-						drop(server);
-					}
-					_ => unreachable!("also ideally")
-				};
-				ready(())
-			});
-		tokio::spawn(server);
+        let server = select(Box::pin(run_server(path.clone())), shutdown_rx).then(|either| {
+            match either {
+                Either::Right((_, server)) => {
+                    drop(server);
+                }
+                _ => unreachable!("also ideally"),
+            };
+            ready(())
+        });
+        tokio::spawn(server);
 
-		tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
 
-		println!("Connecting to client 0...");
-		let mut client_0 = Endpoint::connect(&path).await
-			.expect("failed to open client_0");
-		tokio::time::sleep(Duration::from_secs(2)).await;
-		println!("Connecting to client 1...");
-		let mut client_1 = Endpoint::connect(&path).await
-			.expect("failed to open client_1");
-		let msg = b"hello";
+        println!("Connecting to client 0...");
+        let mut client_0 = Endpoint::connect(&path)
+            .await
+            .expect("failed to open client_0");
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        println!("Connecting to client 1...");
+        let mut client_1 = Endpoint::connect(&path)
+            .await
+            .expect("failed to open client_1");
+        let msg = b"hello";
 
-		let mut rx_buf = vec![0u8; msg.len()];
-		client_0.write_all(msg).await.expect("Unable to write message to client");
-		client_0.read_exact(&mut rx_buf).await.expect("Unable to read message from client");
+        let mut rx_buf = vec![0_u8; msg.len()];
+        client_0
+            .write_all(msg)
+            .await
+            .expect("Unable to write message to client");
+        client_0
+            .read_exact(&mut rx_buf)
+            .await
+            .expect("Unable to read message from client");
 
-		let mut rx_buf2 = vec![0u8; msg.len()];
-		client_1.write_all(msg).await.expect("Unable to write message to client");
-		client_1.read_exact(&mut rx_buf2).await.expect("Unable to read message from client");
+        let mut rx_buf2 = vec![0_u8; msg.len()];
+        client_1
+            .write_all(msg)
+            .await
+            .expect("Unable to write message to client");
+        client_1
+            .read_exact(&mut rx_buf2)
+            .await
+            .expect("Unable to read message from client");
 
-		assert_eq!(rx_buf, msg);
-		assert_eq!(rx_buf2, msg);
+        assert_eq!(rx_buf, msg);
+        assert_eq!(rx_buf2, msg);
 
-		// shutdown server
-		if let Ok(()) = shutdown_tx.send(()) {
-			// wait one second for the file to be deleted.
-			tokio::time::sleep(Duration::from_secs(1)).await;
-			let path = Path::new(&path);
-			// assert that it has
-			assert!(!path.exists());
-		}
+        // shutdown server
+        if let Ok(()) = shutdown_tx.send(()) {
+            // wait one second for the file to be deleted.
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            let path = Path::new(&path);
+            // assert that it has
+            assert!(!path.exists());
+        }
     }
 
     #[tokio::test]
@@ -150,23 +166,27 @@ mod tests {
         is_static(endpoint.incoming());
     }
 
-	#[cfg(windows)]
-	fn create_pipe_with_permissions(attr: SecurityAttributes) -> ::std::io::Result<()> {
-		let path = dummy_endpoint();
+    #[cfg(windows)]
+    fn create_pipe_with_permissions(attr: SecurityAttributes) -> ::std::io::Result<()> {
+        let path = dummy_endpoint();
 
-		let mut endpoint = Endpoint::new(path);
-		endpoint.set_security_attributes(attr);
-		endpoint.incoming().map(|_| ())
-	}
+        let mut endpoint = Endpoint::new(path);
+        endpoint.set_security_attributes(attr);
+        endpoint.incoming().map(|_| ())
+    }
 
-	#[cfg(windows)]
-	#[tokio::test]
-	async fn test_pipe_permissions() {
-		create_pipe_with_permissions(SecurityAttributes::empty())
-			.expect("failed with no attributes");
-		create_pipe_with_permissions(SecurityAttributes::allow_everyone_create().unwrap())
-			.expect("failed with attributes for creating");
-		create_pipe_with_permissions(SecurityAttributes::empty().allow_everyone_connect().unwrap())
-			.expect("failed with attributes for connecting");
-	}
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn test_pipe_permissions() {
+        create_pipe_with_permissions(SecurityAttributes::empty())
+            .expect("failed with no attributes");
+        create_pipe_with_permissions(SecurityAttributes::allow_everyone_create().unwrap())
+            .expect("failed with attributes for creating");
+        create_pipe_with_permissions(
+            SecurityAttributes::empty()
+                .allow_everyone_connect()
+                .unwrap(),
+        )
+        .expect("failed with attributes for connecting");
+    }
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -17,20 +17,20 @@ pub struct SecurityAttributes {
 impl SecurityAttributes {
     /// New default security attributes. These only allow access by the
     /// process’s own user and the system administrator.
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         SecurityAttributes {
             mode: Some(0o600)
         }
     }
 
     /// New security attributes that allow everyone to connect.
-    pub fn allow_everyone_connect(mut self) -> io::Result<Self> {
+    pub const fn allow_everyone_connect(mut self) -> io::Result<Self> {
         self.mode = Some(0o666);
         Ok(self)
     }
 
     /// Set a custom permission on the socket
-    pub fn set_mode(mut self, mode: u16) -> io::Result<Self> {
+    pub const fn set_mode(mut self, mode: u16) -> io::Result<Self> {
         self.mode = Some(mode);
         Ok(self)
     }
@@ -39,10 +39,8 @@ impl SecurityAttributes {
     ///
     /// This does not work on unix, where it is equivalent to
     /// [`SecurityAttributes::allow_everyone_connect`].
-    pub fn allow_everyone_create() -> io::Result<Self> {
-        Ok(SecurityAttributes {
-            mode: None
-        })
+    pub const fn allow_everyone_create() -> io::Result<Self> {
+        Ok(SecurityAttributes { mode: None })
     }
 
     /// called in unix, after server socket has been created
@@ -99,7 +97,7 @@ impl Endpoint {
     }
 
     /// New IPC endpoint at the given path
-    pub fn new(path: String) -> Self {
+    pub const fn new(path: String) -> Self {
         Endpoint {
             path,
             security_attributes: SecurityAttributes::empty(),
@@ -145,7 +143,7 @@ pub struct Connection {
 }
 
 impl Connection {
-    fn wrap(stream: UnixStream) -> Self {
+    const fn wrap(stream: UnixStream) -> Self {
         Self { inner: stream }
     }
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,17 +1,17 @@
+use futures::Stream;
 use libc::chmod;
 use std::ffi::CString;
 use std::io::{self, Error};
-use futures::Stream;
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio::net::{UnixListener, UnixStream};
 use std::path::Path;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::{UnixListener, UnixStream};
 
 /// Socket permissions and ownership on UNIX
 pub struct SecurityAttributes {
     // read/write permissions for owner, group and others in unix octal.
-    mode: Option<u16>
+    mode: Option<u16>,
 }
 
 impl SecurityAttributes {
@@ -65,7 +65,10 @@ pub struct Endpoint {
 
 impl Endpoint {
     /// Stream of incoming connections
-    pub fn incoming(self) -> io::Result<impl Stream<Item = std::io::Result<impl AsyncRead + AsyncWrite>> + 'static> {
+    pub fn incoming(
+        self,
+    ) -> io::Result<impl Stream<Item = std::io::Result<impl AsyncRead + AsyncWrite>> + 'static>
+    {
         let listener = self.inner()?;
         // the call to bind in `inner()` creates the file
         // `apply_permission()` will set the file permissions.
@@ -116,10 +119,7 @@ struct Incoming {
 impl Stream for Incoming {
     type Item = io::Result<UnixStream>;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = Pin::into_inner(self);
         match Pin::new(&mut this.listener).poll_accept(cx) {
             Poll::Pending => Poll::Pending,

--- a/src/win.rs
+++ b/src/win.rs
@@ -214,7 +214,7 @@ impl SecurityAttributes {
     }
 
     /// New default security attributes that allow everyone to connect.
-    pub fn allow_everyone_connect(&self) -> io::Result<SecurityAttributes> {
+    pub fn allow_everyone_connect() -> io::Result<SecurityAttributes> {
         let attributes = Some(InnerAttributes::allow_everyone(
             GENERIC_READ | FILE_WRITE_DATA,
         )?);
@@ -471,8 +471,7 @@ mod test {
 
     #[test]
     fn test_allow_eveyone_read_write() {
-        SecurityAttributes::empty()
-            .allow_everyone_connect()
+        SecurityAttributes::allow_everyone_connect()
             .expect("failed to create security attributes that allow everyone to read and write to/from a pipe");
     }
 }

--- a/src/win.rs
+++ b/src/win.rs
@@ -73,7 +73,7 @@ impl Endpoint {
                 .out_buffer_size(65536)
                 .create_with_security_attributes_raw(
                     &self.path,
-                    self.security_attributes.as_ptr() as *mut libc::c_void,
+                    self.security_attributes.as_ptr().cast::<libc::c_void>(),
                 )
         }?;
         self.created_listener = true;
@@ -256,7 +256,7 @@ impl Sid {
         let result = unsafe {
             #[allow(const_item_mutation)]
             AllocateAndInitializeSid(
-                SECURITY_WORLD_SID_AUTHORITY.as_mut_ptr() as *mut _,
+                SECURITY_WORLD_SID_AUTHORITY.as_mut_ptr().cast(),
                 1,
                 SECURITY_WORLD_RID,
                 0,
@@ -302,7 +302,7 @@ impl<'a> AceWithSid<'a> {
         let mut explicit_access = unsafe { mem::zeroed::<EXPLICIT_ACCESS_W>() };
         explicit_access.Trustee.TrusteeForm = TRUSTEE_IS_SID;
         explicit_access.Trustee.TrusteeType = trustee_type;
-        explicit_access.Trustee.ptstrName = unsafe { sid.as_ptr() as *mut _ };
+        explicit_access.Trustee.ptstrName = unsafe { sid.as_ptr().cast() };
 
         AceWithSid {
             explicit_access,
@@ -340,7 +340,7 @@ impl Acl {
         let result = unsafe {
             SetEntriesInAclW(
                 entries.len() as u32,
-                entries.as_mut_ptr() as *mut _,
+                entries.as_mut_ptr().cast(),
                 ptr::null_mut(),
                 &mut acl_ptr,
             )
@@ -361,7 +361,7 @@ impl Acl {
 impl Drop for Acl {
     fn drop(&mut self) {
         if !self.acl_ptr.is_null() {
-            unsafe { LocalFree(self.acl_ptr as *mut _) };
+            unsafe { LocalFree(self.acl_ptr.cast()) };
         }
     }
 }

--- a/src/win.rs
+++ b/src/win.rs
@@ -1,10 +1,18 @@
 use winapi::shared::winerror::{ERROR_PIPE_BUSY, ERROR_SUCCESS};
-use winapi::um::accctrl::*;
-use winapi::um::aclapi::*;
+use winapi::um::accctrl::{
+    EXPLICIT_ACCESS_W, SET_ACCESS, TRUSTEE_IS_SID, TRUSTEE_IS_WELL_KNOWN_GROUP,
+};
+use winapi::um::aclapi::SetEntriesInAclW;
 use winapi::um::minwinbase::{LPTR, PSECURITY_ATTRIBUTES, SECURITY_ATTRIBUTES};
-use winapi::um::securitybaseapi::*;
+use winapi::um::securitybaseapi::{
+    AllocateAndInitializeSid, FreeSid, InitializeSecurityDescriptor, SetSecurityDescriptorDacl,
+};
 use winapi::um::winbase::{LocalAlloc, LocalFree};
-use winapi::um::winnt::*;
+use winapi::um::winnt::{
+    FILE_WRITE_DATA, GENERIC_READ, GENERIC_WRITE, PACL, PSECURITY_DESCRIPTOR, PSID,
+    SECURITY_DESCRIPTOR_MIN_LENGTH, SECURITY_DESCRIPTOR_REVISION, SECURITY_WORLD_RID,
+    SECURITY_WORLD_SID_AUTHORITY,
+};
 
 use futures::Stream;
 use std::io;
@@ -424,6 +432,7 @@ impl InnerAttributes {
         Ok(InnerAttributes {
             acl,
             descriptor,
+            acl,
             attrs,
         })
     }

--- a/src/win.rs
+++ b/src/win.rs
@@ -113,7 +113,7 @@ impl Endpoint {
     }
 
     /// New IPC endpoint at the given path
-    pub fn new(path: String) -> Self {
+    pub const fn new(path: String) -> Self {
         Endpoint {
             path,
             security_attributes: SecurityAttributes::empty(),
@@ -129,7 +129,7 @@ pub struct Connection {
 
 impl Connection {
     /// Wraps an existing named pipe
-    fn wrap(pipe: NamedPipe) -> Self {
+    const fn wrap(pipe: NamedPipe) -> Self {
         Self { inner: pipe }
     }
 }
@@ -201,7 +201,7 @@ pub const DEFAULT_SECURITY_ATTRIBUTES: SecurityAttributes = SecurityAttributes {
 
 impl SecurityAttributes {
     /// New default security attributes.
-    pub fn empty() -> SecurityAttributes {
+    pub const fn empty() -> Self {
         DEFAULT_SECURITY_ATTRIBUTES
     }
 
@@ -214,7 +214,7 @@ impl SecurityAttributes {
     }
 
     /// Set a custom permission on the socket
-    pub fn set_mode(self, _mode: u32) -> io::Result<Self> {
+    pub const fn set_mode(self, _mode: u32) -> io::Result<SecurityAttributes> {
         // for now, does nothing.
         Ok(self)
     }
@@ -269,7 +269,7 @@ impl Sid {
     }
 
     // Unsafe - the returned pointer is only valid for the lifetime of self.
-    unsafe fn as_ptr(&self) -> PSID {
+    const unsafe fn as_ptr(&self) -> PSID {
         self.sid_ptr
     }
 }
@@ -345,7 +345,7 @@ impl Acl {
         Ok(Acl { acl_ptr })
     }
 
-    unsafe fn as_ptr(&self) -> PACL {
+    const unsafe fn as_ptr(&self) -> PACL {
         self.acl_ptr
     }
 }
@@ -391,7 +391,7 @@ impl SecurityDescriptor {
         Ok(())
     }
 
-    unsafe fn as_ptr(&self) -> PSECURITY_DESCRIPTOR {
+    const unsafe fn as_ptr(&self) -> PSECURITY_DESCRIPTOR {
         self.descriptor_ptr
     }
 }

--- a/src/win.rs
+++ b/src/win.rs
@@ -50,7 +50,7 @@ impl Endpoint {
 
         let stream =
             futures::stream::try_unfold((pipe, self), |(listener, mut endpoint)| async move {
-                let () = listener.connect().await?;
+                listener.connect().await?;
 
                 let new_listener = endpoint.create_listener()?;
 
@@ -430,7 +430,6 @@ impl InnerAttributes {
         let acl = Acl::empty().expect("this should never fail");
 
         Ok(InnerAttributes {
-            acl,
             descriptor,
             acl,
             attrs,


### PR DESCRIPTION
This PR aims to convert all the possibles functions to `const fn` in order to be used in other `const fn` environments, but also includes several changes to cleanup the code. Many of the changed lines of code are due to `cargo fmt`.

- Use the `include` field in `Cargo.toml` to decrease the crate size by 6% (~2.4 KB).
- Use the `is_err()` method in the *server* example instead of the `if let Err(_)` syntax.
- Remove the unused `&self`parameter in `allow_everyone_connect()` function and updated the test to reflect the new syntax. The `empty()` call can be removed since `Endpoint::new()` already sets `security_attributes` to `SecurityAttributes::empty()`
- Use `.cast()` instead of `as *mut _`. `pointer::cast` is safer because it cannot accidentally change the pointer’s mutability nor cast the pointer to other types

Changes have been tested on Linux and Windows. 

If my observations are wrong I am ready to discuss/change them based on your feedback.
