### PR TITLE
Add the winerror feature to winit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1.7.0", features = ["net", "time"] }
 libc = "0.2.65"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["winbase", "winnt", "accctrl", "aclapi", "securitybaseapi", "minwinbase", "winbase"] }
+winapi = { version = "0.3", features = ["winbase", "winnt", "accctrl", "aclapi", "securitybaseapi", "minwinbase", "winbase", "winerror"] }
 
 [dev-dependencies]
 tokio = { version = "1.7.0", features = ["io-util", "rt", "time", "macros"] }


### PR DESCRIPTION
This fixes the build on Windows.

I suggest that you make a new minor release, since this breaks for users of this crate.